### PR TITLE
fix(audit): Increment the Withdrawal Epoch on Queue from EigenLayer

### DIFF
--- a/contracts/restaking/RioLRTWithdrawalQueue.sol
+++ b/contracts/restaking/RioLRTWithdrawalQueue.sol
@@ -22,7 +22,7 @@ contract RioLRTWithdrawalQueue is IRioLRTWithdrawalQueue, OwnableUpgradeable, UU
     IDelegationManager public immutable delegationManager;
 
     /// @notice Current asset withdrawal epochs. Incoming withdrawals are included
-    /// in the current epoch, which will be processed by the asset manager.
+    /// in the current epoch.
     mapping(address asset => uint256 epoch) internal currentEpochsByAsset;
 
     /// @notice The amount of assets owed to users in a given epoch, as well as the state
@@ -202,6 +202,8 @@ contract RioLRTWithdrawalQueue is IRioLRTWithdrawalQueue, OwnableUpgradeable, UU
             epochWithdrawals.amountToBurnAtSettlement -= restakingTokensToBurn;
         }
         epochWithdrawals.aggregateRoot = aggregateRoot;
+
+        currentEpochsByAsset[asset] += 1;
 
         emit EpochQueuedForSettlementFromEigenLayer(
             currentEpoch, asset, assetsReceived, shareValueOfAssetsReceived, restakingTokensToBurn, aggregateRoot

--- a/test/RioLRTWithdrawalQueue.t.sol
+++ b/test/RioLRTWithdrawalQueue.t.sol
@@ -75,6 +75,8 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         // Request a withdrawal and rebalance.
         uint256 withdrawalAmount = ETH_DEPOSIT_SIZE + 1 ether;
         reETH.coordinator.requestWithdrawal(ETH_ADDRESS, withdrawalAmount);
+
+        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         skip(reETH.coordinator.rebalanceDelay());
 
         vm.prank(EOA, EOA);
@@ -85,7 +87,6 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         verifyAndProcessWithdrawalsForValidatorIndexes(operatorDelegator, validatorIndices);
 
         // Settle the withdrawal epoch.
-        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         withdrawals[0] = IDelegationManager.Withdrawal({
             staker: operatorDelegator,
@@ -116,6 +117,7 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertTrue(userSummary.claimed);
         assertEq(amountOut, withdrawalAmount);
         assertEq(address(this).balance - balanceBefore, withdrawalAmount);
+        assertEq(reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS), withdrawalEpoch + 1);
     }
 
     function test_claimWithdrawalsForEpochSomeEtherPaidFromEigenLayerPreciseDecimals() public {
@@ -139,6 +141,8 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         // Request a withdrawal and rebalance.
         uint256 withdrawalAmount = ETH_DEPOSIT_SIZE + 10 ** 18 * 2 - 1;
         uint256 expectedAmountOut = reETH.coordinator.requestWithdrawal(ETH_ADDRESS, withdrawalAmount);
+
+        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         skip(reETH.coordinator.rebalanceDelay());
 
         vm.prank(EOA, EOA);
@@ -151,7 +155,6 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         verifyAndProcessWithdrawalsForValidatorIndexes(operatorDelegator, validatorIndices);
 
         // Settle the withdrawal epoch.
-        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         withdrawals[0] = IDelegationManager.Withdrawal({
             staker: operatorDelegator,
@@ -182,6 +185,7 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertTrue(userSummary.claimed);
         assertEq(amountOut, expectedAmountOut);
         assertEq(address(this).balance - balanceBefore, expectedAmountOut);
+        assertEq(reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS), withdrawalEpoch + 1);
     }
 
     function test_claimWithdrawalsForEpochAllEtherPaidFromEigenLayer() public {
@@ -199,6 +203,8 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         // Request a withdrawal and rebalance.
         uint256 withdrawalAmount = 16 ether;
         reETH.coordinator.requestWithdrawal(ETH_ADDRESS, withdrawalAmount);
+
+        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         skip(reETH.coordinator.rebalanceDelay());
 
         vm.prank(EOA, EOA);
@@ -209,7 +215,6 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         verifyAndProcessWithdrawalsForValidatorIndexes(operatorDelegator, validatorIndices);
 
         // Settle the withdrawal epoch.
-        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         withdrawals[0] = IDelegationManager.Withdrawal({
             staker: operatorDelegator,
@@ -240,6 +245,7 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertTrue(userSummary.claimed);
         assertEq(amountOut, withdrawalAmount);
         assertEq(address(this).balance - balanceBefore, withdrawalAmount);
+        assertEq(reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS), withdrawalEpoch + 1);
     }
 
     function test_claimWithdrawalsForEpochAllEtherPaidFromEigenLayerPreciseDecimals() public {
@@ -259,6 +265,8 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         // Request a withdrawal for an amount with very precise decimals and rebalance.
         uint256 withdrawalAmount = 10 ** 18 - 1;
         uint256 expectedAmountOut = reETH.coordinator.requestWithdrawal(ETH_ADDRESS, withdrawalAmount);
+
+        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         skip(reETH.coordinator.rebalanceDelay());
 
         vm.prank(EOA, EOA);
@@ -269,7 +277,6 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         verifyAndProcessWithdrawalsForValidatorIndexes(operatorDelegator, validatorIndices);
 
         // Settle the withdrawal epoch.
-        uint256 withdrawalEpoch = reETH.withdrawalQueue.getCurrentEpoch(ETH_ADDRESS);
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         withdrawals[0] = IDelegationManager.Withdrawal({
             staker: operatorDelegator,
@@ -363,6 +370,8 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         // Request a withdrawal for an amount greater than the deposit pool balance and rebalance.
         uint256 withdrawalLRTAmount = restakingTokensInDP + restakingTokensInEL;
         reLST.coordinator.requestWithdrawal(CBETH_ADDRESS, withdrawalLRTAmount);
+
+        uint256 withdrawalEpoch = reLST.withdrawalQueue.getCurrentEpoch(CBETH_ADDRESS);
         skip(reLST.coordinator.rebalanceDelay());
 
         vm.prank(EOA, EOA);
@@ -372,7 +381,6 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertApproxEqAbs(reLST.token.totalSupply(), restakingTokensInEL + initialTotalSupply, 100);
 
         // Settle the withdrawal epoch.
-        uint256 withdrawalEpoch = reLST.withdrawalQueue.getCurrentEpoch(CBETH_ADDRESS);
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         withdrawals[0] = IDelegationManager.Withdrawal({
             staker: operatorDelegator,
@@ -403,6 +411,7 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertTrue(userSummary.claimed);
         assertEq(cbETHWithdrawn, expectedTokensOut);
         assertEq(cbETH.balanceOf(address(this)) - balanceBefore, expectedTokensOut);
+        assertEq(reLST.withdrawalQueue.getCurrentEpoch(CBETH_ADDRESS), withdrawalEpoch + 1);
     }
 
     function test_claimWithdrawalsForEpochAllERC20sPaidFromEigenLayer() public {
@@ -422,6 +431,8 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
 
         // Request a withdrawal for the tokens from EigenLayer and rebalance.
         reLST.coordinator.requestWithdrawal(CBETH_ADDRESS, restakingTokensOut);
+
+        uint256 withdrawalEpoch = reLST.withdrawalQueue.getCurrentEpoch(CBETH_ADDRESS);
         skip(reLST.coordinator.rebalanceDelay());
 
         vm.prank(EOA, EOA);
@@ -431,7 +442,6 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertEq(reLST.token.totalSupply(), restakingTokensOut + initialTotalSupply);
 
         // Settle the withdrawal epoch.
-        uint256 withdrawalEpoch = reLST.withdrawalQueue.getCurrentEpoch(CBETH_ADDRESS);
         IDelegationManager.Withdrawal[] memory withdrawals = new IDelegationManager.Withdrawal[](1);
         withdrawals[0] = IDelegationManager.Withdrawal({
             staker: operatorDelegator,
@@ -462,6 +472,7 @@ contract RioLRTWithdrawalQueueTest is RioDeployer {
         assertTrue(userSummary.claimed);
         assertEq(cbETHWithdrawn, amount);
         assertEq(cbETH.balanceOf(address(this)) - balanceBefore, amount);
+        assertEq(reLST.withdrawalQueue.getCurrentEpoch(CBETH_ADDRESS), withdrawalEpoch + 1);
     }
 
     function test_claimWithdrawalsForManyEpochs() public {


### PR DESCRIPTION
This PR resolves https://github.com/sherlock-audit/2024-02-rio-network-core-protocol-judging/issues/4. `currentEpochsByAsset` is now correctly incremented in `queueCurrentEpochSettlement`.