### PR TITLE
fix(audit): Fix Out of Gas Error on ETH Reward Transfers

### DIFF
--- a/contracts/utils/Asset.sol
+++ b/contracts/utils/Asset.sol
@@ -39,7 +39,7 @@ library Asset {
     /// @param amount The amount of ETH to send.
     /// @dev This function limits the gas passed with the call to 10,000.
     function transferETH(address recipient, uint256 amount) internal {
-        (bool success,) = recipient.call{value: amount, gas: 10_000}('');
+        (bool success,) = recipient.call{value: amount}('');
         if (!success) {
             revert ETH_TRANSFER_FAILED();
         }

--- a/test/RioLRTOperatorDelegator.t.sol
+++ b/test/RioLRTOperatorDelegator.t.sol
@@ -120,4 +120,12 @@ contract RioLRTOperatorDelegatorTest is RioDeployer {
         assertEq(delegatorContract.getETHQueuedForWithdrawal(), ethQueuedBefore - SCRAPE_AMOUNT);
         assertEq(address(reETH.depositPool).balance, depositPoolBalanceBefore + SCRAPE_AMOUNT);
     }
+
+    function test_forwardingETHToRewardDistributorSucceeds() public {
+        uint8 operatorId = addOperatorDelegator(reETH.operatorRegistry, address(reETH.rewardDistributor));
+        address operatorDelegator = reETH.operatorRegistry.getOperatorDetails(operatorId).delegator;
+
+        (bool success, ) = operatorDelegator.call{value: 1 ether}('');
+        assertTrue(success);
+    }
 }


### PR DESCRIPTION
This PR resolves https://github.com/sherlock-audit/2024-02-rio-network-core-protocol-judging/issues/185. We now forward all gas on ETH transfer via `transferETH`, and have verified no functions are susceptible to reentrancy.