### PR TITLE
fix(audit): Fix Revert When Depositing ERC20 with Missing Returns

### DIFF
--- a/contracts/restaking/RioLRTIssuer.sol
+++ b/contracts/restaking/RioLRTIssuer.sol
@@ -169,7 +169,7 @@ contract RioLRTIssuer is IRioLRTIssuer, OwnableUpgradeable, UUPSUpgradeable {
         }
 
         IERC20(asset).safeTransferFrom(msg.sender, address(this), amount);
-        IERC20(asset).approve(address(coordinator), amount);
+        IERC20(asset).forceApprove(address(coordinator), amount);
 
         coordinator.deposit(asset, amount);
     }

--- a/test/RioLRTIssuer.t.sol
+++ b/test/RioLRTIssuer.t.sol
@@ -3,8 +3,10 @@ pragma solidity 0.8.23;
 
 import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import {BEACON_CHAIN_STRATEGY, ETH_ADDRESS, MIN_SACRIFICIAL_DEPOSIT} from 'contracts/utils/Constants.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {IRioLRTAssetRegistry} from 'contracts/interfaces/IRioLRTAssetRegistry.sol';
 import {IRioLRTIssuer} from 'contracts/interfaces/IRioLRTIssuer.sol';
+import {MissingReturnERC20} from 'test/utils/MissingReturnERC20.sol';
 import {MockPriceFeed} from 'test/utils/MockPriceFeed.sol';
 import {IRioLRT} from 'contracts/interfaces/IRioLRT.sol';
 import {RioDeployer} from 'test/utils/RioDeployer.sol';
@@ -105,5 +107,70 @@ contract RioLRTIssuerTest is RioDeployer {
 
         assertEq(IRioLRT(deployment.token).totalSupply(), EXPECTED_RETH);
         assertEq(IRioLRT(deployment.token).balanceOf(address(issuer)), EXPECTED_RETH);
+    }
+
+    function test_issuesLRTWhenDepositingERC20WithMissingReturn() public {
+        MissingReturnERC20 mrToken = new MissingReturnERC20('Missing Return Token', 'mrToken');
+
+        address mrTokenAddress = address(mrToken);
+        address mrTokenPriceFeed = address(new MockPriceFeed(1.1 ether));
+
+        address mrTokenStrategy = address(0x555);
+        _deployTo(
+            type(TransparentUpgradeableProxy).creationCode,
+            abi.encode(
+                STRATEGY_BASE_TVL_LIMITS_IMPL_ADDRESS,
+                OWNER_ADDRESS,
+                abi.encodeWithSignature(
+                    'initialize(uint256,uint256,address,address)',
+                    type(uint256).max, // Max Per Deposit
+                    type(uint256).max, // Max Total Deposits
+                    mrTokenAddress, // Underlying Token
+                    address(1) // Pauser Registry
+                )
+            ),
+            mrTokenStrategy
+        );
+
+        IRioLRTAssetRegistry.AssetConfig[] memory assets = new IRioLRTAssetRegistry.AssetConfig[](1);
+        assets[0] = IRioLRTAssetRegistry.AssetConfig({
+            asset: mrTokenAddress,
+            depositCap: 1_000_000 ether,
+            strategy: mrTokenStrategy,
+            priceFeed: mrTokenPriceFeed
+        });
+
+        mrToken.approve(address(issuer), 0.01 ether);
+        IRioLRTIssuer.LRTDeployment memory deployment = issuer.issueLRT(
+            'Restaked MRT',
+            'reMRT',
+            IRioLRTIssuer.LRTConfig({
+                assets: assets,
+                priceFeedDecimals: 18,
+                operatorRewardPool: address(this),
+                treasury: address(this),
+                deposit: IRioLRTIssuer.SacrificialDeposit({asset: mrTokenAddress, amount: 0.01 ether})
+            })
+        );
+        assertTrue(issuer.isTokenFromFactory(deployment.token));
+
+        assertNotEq(deployment.token, address(0));
+        assertNotEq(deployment.coordinator, address(0));
+        assertNotEq(deployment.assetRegistry, address(0));
+        assertNotEq(deployment.operatorRegistry, address(0));
+        assertNotEq(deployment.avsRegistry, address(0));
+        assertNotEq(deployment.depositPool, address(0));
+        assertNotEq(deployment.withdrawalQueue, address(0));
+        assertNotEq(deployment.rewardDistributor, address(0));
+
+        IRioLRTAssetRegistry assetRegistry = IRioLRTAssetRegistry(deployment.assetRegistry);
+        address[] memory supportedAssets = assetRegistry.getSupportedAssets();
+        assertEq(supportedAssets.length, 1);
+
+        assertEq(supportedAssets[0], mrTokenAddress);
+
+        uint256 EXPECTED_MRT = (MockPriceFeed(mrTokenPriceFeed).getPrice() * 0.01 ether) / 1e18;
+
+        assertEq(IRioLRT(deployment.token).totalSupply(), EXPECTED_MRT);
     }
 }

--- a/test/utils/MissingReturnERC20.sol
+++ b/test/utils/MissingReturnERC20.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.23;
+
+contract MissingReturnERC20 {
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+
+    uint8 public constant decimals = 18;
+
+    string public name;
+    string public symbol;
+
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    constructor(string memory name_, string memory symbol_) {
+        name = name_;
+        symbol = symbol_;
+
+        totalSupply = 1_000_000 * 10 ** decimals;
+        balanceOf[msg.sender] = totalSupply;
+
+        emit Transfer(address(0), msg.sender, totalSupply);
+    }
+
+    function transfer(address dst, uint256 wad) external {
+        transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint256 wad) public {
+        require(balanceOf[src] >= wad, 'insufficient-balance');
+        if (src != msg.sender && allowance[src][msg.sender] != type(uint256).max) {
+            require(allowance[src][msg.sender] >= wad, 'insufficient-allowance');
+            allowance[src][msg.sender] -= wad;
+        }
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        emit Transfer(src, dst, wad);
+    }
+
+    function approve(address usr, uint256 wad) external {
+        allowance[msg.sender][usr] = wad;
+        emit Approval(msg.sender, usr, wad);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/sherlock-audit/2024-02-rio-network-core-protocol-judging/issues/189.