### PR TITLE
fix(audit): Fix Precision Loss in Decimal Normalization

### DIFF
--- a/contracts/restaking/RioLRTAssetRegistry.sol
+++ b/contracts/restaking/RioLRTAssetRegistry.sol
@@ -192,7 +192,7 @@ contract RioLRTAssetRegistry is IRioLRTAssetRegistry, OwnableUpgradeable, UUPSUp
         address priceFeed = assetInfo[asset].priceFeed;
         uint256 price = getPrice(priceFeed);
 
-        return _normalizeDecimals(price * amount / priceScale, assetInfo[asset].decimals, priceFeedDecimals);
+        return _normalizeDecimals(price * amount, assetInfo[asset].decimals, priceFeedDecimals) / priceScale;
     }
 
     /// @notice Converts the unit of account value to its equivalent in the asset. The unit of
@@ -206,7 +206,7 @@ contract RioLRTAssetRegistry is IRioLRTAssetRegistry, OwnableUpgradeable, UUPSUp
         address priceFeed = assetInfo[asset].priceFeed;
         uint256 price = getPrice(priceFeed);
 
-        return _normalizeDecimals(value * priceScale / price, priceFeedDecimals, assetInfo[asset].decimals);
+        return _normalizeDecimals(value * priceScale, priceFeedDecimals, assetInfo[asset].decimals) / price;
     }
 
     /// @notice Converts an amount of an asset to the equivalent amount of EigenLayer shares.

--- a/test/RioLRTAssetRegistry.t.sol
+++ b/test/RioLRTAssetRegistry.t.sol
@@ -3,8 +3,10 @@ pragma solidity 0.8.23;
 
 import {MockERC20} from '@solady/../test/utils/mocks/MockERC20.sol';
 import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {IRioLRTAssetRegistry} from 'contracts/interfaces/IRioLRTAssetRegistry.sol';
 import {ETH_ADDRESS, BEACON_CHAIN_STRATEGY} from 'contracts/utils/Constants.sol';
+import {RioLRTAssetRegistry} from 'contracts/restaking/RioLRTAssetRegistry.sol';
 import {MockPriceFeed} from 'test/utils/MockPriceFeed.sol';
 import {MockStrategy} from 'test/utils/MockStrategy.sol';
 import {RioDeployer} from 'test/utils/RioDeployer.sol';
@@ -129,5 +131,56 @@ contract RioLRTAssetRegistryTest is RioDeployer {
 
         reLST.assetRegistry.removeAsset(RETH_ADDRESS);
         assertEq(reLST.assetRegistry.getSupportedAssets().length, 0);
+    }
+
+    function test_convertToUnitOfAccountFromAssetRetainsPrecision() public {
+        MockERC20 token_ = new MockERC20('Test', 'TEST', 6);
+        token_.mint(address(this), 100e6);
+
+        address token = address(token_);
+        address tokenStrategy = makeAddr('TOKEN_STRATEGY');
+
+        _deployStrategyForToken(token, tokenStrategy);
+
+        IRioLRTAssetRegistry.AssetConfig[] memory assets = new IRioLRTAssetRegistry.AssetConfig[](1);
+        assets[0] = IRioLRTAssetRegistry.AssetConfig({
+            asset: token,
+            depositCap: 0,
+            strategy: tokenStrategy,
+            priceFeed: address(new MockPriceFeed(294104713183814))
+        });
+
+        // Deploy an LRT instance containing an underlying token with 6 decimals and a price feed with 18 decimals.
+        TestLRTDeployment memory td = issueRestakedToken(assets, 18, address(this), address(this));
+
+        uint256 value = td.assetRegistry.convertToUnitOfAccountFromAsset(token, 100e6);
+        assertEq(value, 29410471318381400);
+    }
+
+    function test_convertFromUnitOfAccountToAssetRetainsPrecision() public {
+        MockERC20 token_ = new MockERC20('Test', 'TEST', 18);
+        token_.mint(address(this), 100e18);
+
+        address token = address(token_);
+        address tokenStrategy = makeAddr('TOKEN_STRATEGY');
+
+        _deployStrategyForToken(token, tokenStrategy);
+
+        MockPriceFeed priceFeed = new MockPriceFeed(123456789);
+        priceFeed.setDecimals(8);
+
+        IRioLRTAssetRegistry.AssetConfig[] memory assets = new IRioLRTAssetRegistry.AssetConfig[](1);
+        assets[0] = IRioLRTAssetRegistry.AssetConfig({
+            asset: token,
+            depositCap: 0,
+            strategy: tokenStrategy,
+            priceFeed: address(priceFeed)
+        });
+
+        // Deploy an LRT instance containing an underlying token with 18 decimals and a price feed with 8 decimals.
+        TestLRTDeployment memory td = issueRestakedToken(assets, 8, address(this), address(this));
+
+        uint256 amount = td.assetRegistry.convertFromUnitOfAccountToAsset(token, 294104713);
+        assertEq(amount, 2382248196978458592);
     }
 }

--- a/test/utils/EigenLayerDeployer.sol
+++ b/test/utils/EigenLayerDeployer.sol
@@ -208,36 +208,8 @@ abstract contract EigenLayerDeployer is Test {
         );
 
         // Deploy LST strategies
-        _deployTo(
-            type(TransparentUpgradeableProxy).creationCode,
-            abi.encode(
-                STRATEGY_BASE_TVL_LIMITS_IMPL_ADDRESS,
-                OWNER_ADDRESS,
-                abi.encodeWithSignature(
-                    'initialize(uint256,uint256,address,address)',
-                    type(uint256).max, // Max Per Deposit
-                    type(uint256).max, // Max Total Deposits
-                    RETH_ADDRESS, // Underlying Token
-                    address(1) // Pauser Registry
-                )
-            ),
-            RETH_STRATEGY
-        );
-        _deployTo(
-            type(TransparentUpgradeableProxy).creationCode,
-            abi.encode(
-                STRATEGY_BASE_TVL_LIMITS_IMPL_ADDRESS,
-                OWNER_ADDRESS,
-                abi.encodeWithSignature(
-                    'initialize(uint256,uint256,address,address)',
-                    type(uint256).max, // Max Per Deposit
-                    type(uint256).max, // Max Total Deposits
-                    CBETH_ADDRESS, // Underlying Token
-                    address(1) // Pauser Registry
-                )
-            ),
-            CBETH_STRATEGY
-        );
+        _deployStrategyForToken(RETH_ADDRESS, RETH_STRATEGY);
+        _deployStrategyForToken(CBETH_ADDRESS, CBETH_STRATEGY);
 
         // Whitelist strategies
         address[] memory strategies = new address[](2);
@@ -257,5 +229,26 @@ abstract contract EigenLayerDeployer is Test {
         (bool success, bytes memory runtimeBytecode) = where.call('');
         require(success, 'StdCheats deployCodeTo(string,bytes,uint256,address): Failed to create runtime bytecode.');
         vm.etch(where, runtimeBytecode);
+    }
+
+    /// @dev Deploys an EigenLayer strategy for `token` to the provided address.
+    /// @param token The underlying token address.
+    /// @param where The address to deploy the strategy to.
+    function _deployStrategyForToken(address token, address where) internal {
+        _deployTo(
+            type(TransparentUpgradeableProxy).creationCode,
+            abi.encode(
+                STRATEGY_BASE_TVL_LIMITS_IMPL_ADDRESS,
+                OWNER_ADDRESS,
+                abi.encodeWithSignature(
+                    'initialize(uint256,uint256,address,address)',
+                    type(uint256).max, // Max Per Deposit
+                    type(uint256).max, // Max Total Deposits
+                    token, // Underlying Token
+                    address(1) // Pauser Registry
+                )
+            ),
+            where
+        );
     }
 }


### PR DESCRIPTION
This PR resolves https://github.com/sherlock-audit/2024-02-rio-network-core-protocol-judging/issues/264 by dividing after decimal normalization.